### PR TITLE
ClearText issue fix; Closes #19

### DIFF
--- a/app/src/main/java/com/ehnyn/moviesapp/networking/MovieData.java
+++ b/app/src/main/java/com/ehnyn/moviesapp/networking/MovieData.java
@@ -1,7 +1,6 @@
 package com.ehnyn.moviesapp.networking;
 
 import androidx.annotation.NonNull;
-
 import com.ehnyn.moviesapp.models.MovieReviewModel;
 import com.ehnyn.moviesapp.models.MovieTrailerModel;
 import com.ehnyn.moviesapp.models.MoviesModel;

--- a/app/src/main/java/com/ehnyn/moviesapp/utils/APPConstant.java
+++ b/app/src/main/java/com/ehnyn/moviesapp/utils/APPConstant.java
@@ -2,9 +2,9 @@ package com.ehnyn.moviesapp.utils;
 
 public class APPConstant {
 
-    public static final String MOVIE_POSTER_BASE_URL = "http://image.tmdb.org/t/p/";
+    public static final String MOVIE_POSTER_BASE_URL = "https://image.tmdb.org/t/p/";
 
-    public static final String API_BASE_URL = "http://api.themoviedb.org/3/";
+    public static final String API_BASE_URL = "https://api.themoviedb.org/3/";
 
     public static final String MOVIE_POSTER_SIZE = "w185/";
 


### PR DESCRIPTION
In Android 9 and above, cleartext support is removed by default.
Therefore, update api URL to use HTTPS in order to fix the cleartext traffic error. 